### PR TITLE
Make deep-equal module a dependancy for production

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "@sasadjolic/express-auth",
-  "version": "1.0.0",
+  "name": "express-authenticated",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -281,8 +281,7 @@
     "deep-equal": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
-      "dev": true
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
     },
     "delayed-stream": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -42,12 +42,12 @@
     ]
   },
   "devDependencies": {
-    "deep-equal": "^1.0.1",
     "express": "^4.16.4",
     "mocha": "^5.2.0",
     "request": "^2.88.0"
   },
   "dependencies": {
+    "deep-equal": "^1.0.1",
     "@types/express": "^4.16.0",
     "@types/node": "^10.11.2",
     "node-webtokens": "^1.0.0"


### PR DESCRIPTION
This module is used in the main index.js file and will not be installed in production environments