### PR TITLE
changed payload type to be key value pairs

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -32,6 +32,6 @@ export class Authenticator {
     public authorized(filter: express.Router): express.RequestHandler
 }
 
-export function encode(content: { payload: object, issuer: string, secret: string } ): Promise<string>
+export function encode(content: { payload: { [key: string]: string }, issuer: string, secret: string } ): Promise<string>
 
-export function decode(content: { token: string, issuer: string, secret: string } ): Promise<object>
+export function decode(content: { token: string, issuer: string, secret: string } ): Promise<{ [key: string]: string }>


### PR DESCRIPTION
Upon experimenting with the tool, I've found that payload type being an object gave me trouble because I need to cast it to any before I can call any properties. 

Switching to key value pairs should make typescript happy. 😄 